### PR TITLE
Add a new non strict check on an email

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new

--- a/email_format.gemspec
+++ b/email_format.gemspec
@@ -4,24 +4,24 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'email_format/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "email_format"
+  spec.name          = 'email_format'
   spec.version       = EmailFormat::VERSION
-  spec.authors       = ["johnotander"]
-  spec.email         = ["johnotander@gmail.com"]
+  spec.authors       = ['johnotander']
+  spec.email         = ['johnotander@gmail.com']
   spec.description   = %q{Validates the email format.}
   spec.summary       = %q{Validates the email format with the email_regex gem.}
-  spec.homepage      = "https://github.com/johnotander/email_format"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/johnotander/email_format'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake'
 
-  spec.add_dependency "activemodel"
-  spec.add_dependency "email_regex"
+  spec.add_dependency 'activemodel'
+  spec.add_dependency 'email_regex'
 end

--- a/lib/email_format.rb
+++ b/lib/email_format.rb
@@ -1,10 +1,13 @@
-require "email_regex"
-require "email_format/version"
-require "email_format/email_format_validator"
+require 'email_regex'
+require 'email_format/version'
+require 'email_format/email_format_validator'
 
 module EmailFormat
-
-  def self.valid?(email)
-    !!(email =~ EmailRegex::EMAIL_ADDRESS_REGEX)
+  def self.valid?(email, strict)
+    if strict
+      !!(email =~ EmailRegex::EMAIL_ADDRESS_REGEX)
+    else
+      !!(email =~ /^[\S&&[^@]]+@[\S&&[^@]]+$/)
+    end
   end
 end

--- a/lib/email_format/email_format_validator.rb
+++ b/lib/email_format/email_format_validator.rb
@@ -1,7 +1,6 @@
 class EmailFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless EmailFormat.valid?(value)
-      record.errors[attribute] << (options[:message] || "is invalid")
-    end
+    return if EmailFormat.valid?(value, options[:strict])
+    record.errors[attribute] << (options[:message] || 'is invalid')
   end
 end

--- a/lib/email_format/version.rb
+++ b/lib/email_format/version.rb
@@ -1,3 +1,3 @@
 module EmailFormat
-  VERSION = "0.0.2"
+  VERSION = '0.0.2'
 end

--- a/spec/email_format_validator_spec.rb
+++ b/spec/email_format_validator_spec.rb
@@ -1,47 +1,84 @@
 require 'spec_helper'
 
 describe EmailFormatValidator do
-
   let(:fake_model) { FakeModel.new }
+  let(:fake_model_strict) { FakeModelStrict.new }
 
-  context "with valid emails" do
+  describe 'valid emails' do
+    context 'with strict email requirements' do
+      let(:valid_emails) { %w(valid@email.com another.valid@email.email.net) }
 
-    let(:valid_emails) { %w(valid@email.com another.valid@email.email.net) }
+      it 'should be happy' do
+        valid_emails.each do |email|
+          fake_model_strict.email = email
+          expect(fake_model_strict.valid?).to be_truthy
+        end
+      end
+    end
 
-    it "should be happy" do
-      valid_emails.each do |email|
-        fake_model.email = email
-        expect(fake_model.valid?).to be_truthy
+    context 'with non strict requirements' do
+      let(:valid_emails) do
+        %w(valid@email.com
+           another.valid@email.email.net
+           valid@a
+           a@vaild
+           a@a)
+      end
+
+      it 'should be happy' do
+        valid_emails.each do |email|
+          fake_model.email = email
+          expect(fake_model.valid?).to be_truthy
+        end
       end
     end
   end
 
-  context "with invalid emails" do
+  describe 'invalid emails' do
+    context 'with strict requirements' do
+      let(:invalid_emails) do
+        %w(invalid_email@
+           another_invalid_email@@email.email
+           invalid
+           bad@email@here
+           @bad_email
+           another@bad,email)
+      end
 
-    let(:invalid_emails) { %w(invalid_email@
-                              another_invalid_email@@email.email
-                              invalid
-                              bad@email@here
-                              @bad_email
-                              another@bad,email) }
+      it 'should not be happy' do
+        invalid_emails.each do |email|
+          fake_model_strict.email = email
+          expect(fake_model_strict.valid?).to be_falsey
+        end
+      end
+    end
 
-    it "shouldn't be happy" do
-      invalid_emails.each do |email|
-        fake_model.email = email
-        expect(fake_model.valid?).to be_falsey
+    context 'with non strict requirements' do
+      let(:invalid_emails) do
+        %w(invalid_email@
+           another_invalid_email@@email.email
+           invalid
+           bad@email@here
+           @bad_email)
+      end
+
+      it 'should not be happy' do
+        invalid_emails.each do |email|
+          fake_model.email = email
+          expect(fake_model.valid?).to be_falsey
+        end
       end
     end
   end
 
-  context "with allow_blank: true" do
-
-    let(:fake_model)   { FakeModelWithBlankEmail.new }
+  context 'with allow_blank: true' do
+    let(:fake_model_strict)   { FakeModelWithBlankEmail.new }
     let(:blank_emails) { ['', nil, ' '] }
 
-    it "should allow blank emails" do
+    it 'should allow blank emails' do
       blank_emails.each do |blank_email|
-        fake_model.email = blank_email
-        expect(fake_model.valid?).to be_truthy
+        fake_model_strict.email = blank_email
+        expect(fake_model_strict.valid?).to be_truthy
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,14 @@ class FakeModel
   validates :email, email_format: true
 end
 
+class FakeModelStrict
+  include ActiveModel::Validations
+
+  attr_accessor :email
+
+  validates :email, email_format: { strict: true }
+end
+
 class FakeModelWithBlankEmail
   include ActiveModel::Validations
 


### PR DESCRIPTION
Adds a new non strict check that will simply check if an email
contains an `@` symbol with at least one non whitespace character
before and after. Also limits emails to one `@` symbol.

By default, the check will not be strict. In order for the stricter
test to be used, the developer will now need to pass:
`validates :email, email_format: { strict: true }`
